### PR TITLE
Fix compile warnings from Spring 4 / Jackson 3 / Kotlin 2.3 upgrade

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -98,7 +98,7 @@ tasks.withType<JavaCompile> {
 
 tasks.withType<KotlinCompile> {
     compilerOptions {
-        freeCompilerArgs.addAll("-Xjsr305=strict", "-Xjvm-default=all")
+        freeCompilerArgs.addAll("-Xjsr305=strict", "-jvm-default=enable")
         jvmTarget.set(JvmTarget.JVM_24)
     }
 }

--- a/src/main/kotlin/br/com/jiratorio/configuration/ErrorHandler.kt
+++ b/src/main/kotlin/br/com/jiratorio/configuration/ErrorHandler.kt
@@ -21,7 +21,7 @@ class ErrorHandler(
     @ExceptionHandler(KotlinInvalidNullException::class)
     fun handleKotlinInvalidNullException(e: KotlinInvalidNullException): ResponseEntity<Map<String, List<String>>> =
         ResponseEntity(
-            mapOf((e.kotlinPropertyName ?: "field") to listOf(messageResolver.resolve("jakarta.validation.constraints.NotNull.message"))),
+            mapOf(e.kotlinPropertyName to listOf(messageResolver.resolve("jakarta.validation.constraints.NotNull.message"))),
             HttpStatus.BAD_REQUEST
         )
 

--- a/src/main/kotlin/br/com/jiratorio/domain/request/CreateIssuePeriodRequest.kt
+++ b/src/main/kotlin/br/com/jiratorio/domain/request/CreateIssuePeriodRequest.kt
@@ -9,11 +9,11 @@ import jakarta.validation.constraints.NotNull
 
 data class CreateIssuePeriodRequest(
 
-    @JsonFormat(pattern = "dd/MM/yyyy")
+    @field:JsonFormat(pattern = "dd/MM/yyyy")
     @field:NotNull(message = "{validations.required-start-date}")
     val startDate: LocalDate,
 
-    @JsonFormat(pattern = "dd/MM/yyyy")
+    @field:JsonFormat(pattern = "dd/MM/yyyy")
     @field:NotNull(message = "{validations.required-end-date}")
     val endDate: LocalDate
 

--- a/src/main/kotlin/br/com/jiratorio/domain/request/HolidayRequest.kt
+++ b/src/main/kotlin/br/com/jiratorio/domain/request/HolidayRequest.kt
@@ -8,7 +8,7 @@ import jakarta.validation.constraints.NotNull
 data class HolidayRequest(
 
     @field:NotNull
-    @JsonFormat(pattern = "dd/MM/yyyy")
+    @field:JsonFormat(pattern = "dd/MM/yyyy")
     val date: LocalDate,
 
     @field:NotBlank

--- a/src/main/kotlin/br/com/jiratorio/domain/response/EstimateIssueResponse.kt
+++ b/src/main/kotlin/br/com/jiratorio/domain/response/EstimateIssueResponse.kt
@@ -11,16 +11,16 @@ data class EstimateIssueResponse(
 
     val startDate: String,
 
-    @JsonFormat(pattern = "dd/MM/yyyy")
+    @field:JsonFormat(pattern = "dd/MM/yyyy")
     val estimateDateAvg: LocalDate,
 
-    @JsonFormat(pattern = "dd/MM/yyyy")
+    @field:JsonFormat(pattern = "dd/MM/yyyy")
     val estimateDatePercentile50: LocalDate,
 
-    @JsonFormat(pattern = "dd/MM/yyyy")
+    @field:JsonFormat(pattern = "dd/MM/yyyy")
     val estimateDatePercentile75: LocalDate,
 
-    @JsonFormat(pattern = "dd/MM/yyyy")
+    @field:JsonFormat(pattern = "dd/MM/yyyy")
     val estimateDatePercentile90: LocalDate,
 
     val leadTime: Long,

--- a/src/main/kotlin/br/com/jiratorio/extension/JsonNodeExtension.kt
+++ b/src/main/kotlin/br/com/jiratorio/extension/JsonNodeExtension.kt
@@ -26,7 +26,7 @@ fun JsonNode?.extractValue(): String? {
         }
     }
 
-    return this.asText(null)
+    return this.asString()
 }
 
 fun JsonNode.parallelStream(): Stream<JsonNode> =

--- a/src/main/kotlin/br/com/jiratorio/extension/jdbctemplate/JdbcOperationsExtension.kt
+++ b/src/main/kotlin/br/com/jiratorio/extension/jdbctemplate/JdbcOperationsExtension.kt
@@ -4,4 +4,4 @@ import org.springframework.jdbc.core.JdbcOperations
 import org.springframework.jdbc.core.SingleColumnRowMapper
 
 inline fun <reified T : Any> JdbcOperations.queryForSet(sql: String, args: Array<out Any>): Set<T> =
-    query(sql, args, SetRowMapperResultSetExtractor(SingleColumnRowMapper(T::class.java)))?.filterNotNull()?.toSet() ?: emptySet()
+    query(sql, SetRowMapperResultSetExtractor(SingleColumnRowMapper(T::class.java)), *args).filterNotNull().toSet()

--- a/src/main/kotlin/br/com/jiratorio/extension/jdbctemplate/NamedParameterJdbcOperationsExtension.kt
+++ b/src/main/kotlin/br/com/jiratorio/extension/jdbctemplate/NamedParameterJdbcOperationsExtension.kt
@@ -6,4 +6,4 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcOperations
 import org.springframework.jdbc.core.namedparam.SqlParameterSource
 
 inline fun <reified T : Any> NamedParameterJdbcOperations.queryForSet(sql: String, sqlParameterSource: SqlParameterSource = MapSqlParameterSource()): Set<T> =
-    query(sql, sqlParameterSource, SetRowMapperResultSetExtractor(SingleColumnRowMapper(T::class.java)))?.filterNotNull()?.toSet() ?: emptySet()
+    query(sql, sqlParameterSource, SetRowMapperResultSetExtractor(SingleColumnRowMapper(T::class.java))).filterNotNull().toSet()

--- a/src/main/kotlin/br/com/jiratorio/holiday/client/config/HolidayClientConfig.kt
+++ b/src/main/kotlin/br/com/jiratorio/holiday/client/config/HolidayClientConfig.kt
@@ -11,7 +11,7 @@ import org.springframework.web.service.invoker.HttpServiceProxyFactory
 
 @Configuration
 class HolidayClientConfig(
-    @Value("\${holiday.url}") private val holidayUrl: String,
+    @param:Value("\${holiday.url}") private val holidayUrl: String,
 ) {
 
     @Bean

--- a/src/main/kotlin/br/com/jiratorio/holiday/domain/HolidayApiResponse.kt
+++ b/src/main/kotlin/br/com/jiratorio/holiday/domain/HolidayApiResponse.kt
@@ -5,7 +5,7 @@ import java.time.LocalDate
 
 data class HolidayApiResponse(
 
-    @JsonFormat(pattern = "dd/MM/yyyy")
+    @field:JsonFormat(pattern = "dd/MM/yyyy")
     val date: LocalDate,
 
     val name: String,

--- a/src/main/kotlin/br/com/jiratorio/holiday/domain/HolidayXmlResponse.kt
+++ b/src/main/kotlin/br/com/jiratorio/holiday/domain/HolidayXmlResponse.kt
@@ -1,3 +1,5 @@
+@file:Suppress("DEPRECATION")
+
 package br.com.jiratorio.holiday.domain
 
 import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper
@@ -6,8 +8,8 @@ import tools.jackson.dataformat.xml.annotation.JacksonXmlRootElement
 
 @JacksonXmlRootElement(localName = "events")
 data class HolidayEventsXml(
-    @JacksonXmlElementWrapper(useWrapping = false)
-    @JacksonXmlProperty(localName = "event")
+    @field:JacksonXmlElementWrapper(useWrapping = false)
+    @field:JacksonXmlProperty(localName = "event")
     val event: List<HolidayEventXml> = emptyList(),
 )
 
@@ -16,7 +18,7 @@ data class HolidayEventXml(
     val name: String? = null,
     val description: String? = null,
     val type: String? = null,
-    @JacksonXmlProperty(localName = "type_code")
+    @field:JacksonXmlProperty(localName = "type_code")
     val typeCode: Int? = null,
     val link: String? = null,
 )

--- a/src/main/kotlin/br/com/jiratorio/internationalization/HeaderLocaleResolver.kt
+++ b/src/main/kotlin/br/com/jiratorio/internationalization/HeaderLocaleResolver.kt
@@ -9,10 +9,10 @@ import jakarta.servlet.http.HttpServletResponse
 
 @Component(DispatcherServlet.LOCALE_RESOLVER_BEAN_NAME)
 class HeaderLocaleResolver : LocaleResolver {
-    private val defaultLocale = Locale("pt", "BR")
+    private val defaultLocale = Locale.of("pt", "BR")
 
     private val supportedLocales = mapOf(
-        "en" to Locale("en"),
+        "en" to Locale.of("en"),
         "pt-BR" to defaultLocale
     )
 

--- a/src/main/kotlin/br/com/jiratorio/internationalization/MessageResolverImpl.kt
+++ b/src/main/kotlin/br/com/jiratorio/internationalization/MessageResolverImpl.kt
@@ -19,7 +19,8 @@ class MessageResolverImpl(
 
     override val locale: Locale = localeResolver.resolveLocale(request)
 
+    @Suppress("UNCHECKED_CAST")
     override fun resolve(key: String, vararg args: Any?): String =
-        messageSource.getMessage(key, args as Array<out Any>?, locale)
+        messageSource.getMessage(key, args as Array<Any>?, locale)
 
 }

--- a/src/main/kotlin/br/com/jiratorio/jira/client/config/AuthClientConfiguration.kt
+++ b/src/main/kotlin/br/com/jiratorio/jira/client/config/AuthClientConfiguration.kt
@@ -15,7 +15,7 @@ import org.springframework.web.service.invoker.HttpServiceProxyFactory
 @Configuration
 class AuthClientConfiguration(
     private val messageResolver: MessageResolver,
-    @Value("\${jira.url}") private val jiraUrl: String,
+    @param:Value("\${jira.url}") private val jiraUrl: String,
 ) {
 
     private val log = LoggerFactory.getLogger(javaClass)

--- a/src/main/kotlin/br/com/jiratorio/jira/client/config/JiraClientConfiguration.kt
+++ b/src/main/kotlin/br/com/jiratorio/jira/client/config/JiraClientConfiguration.kt
@@ -27,7 +27,7 @@ class JiraClientConfiguration(
     private val objectMapper: ObjectMapper,
     private val currentUser: CurrentUser,
     private val messageResolver: MessageResolver,
-    @Value("\${jira.url}") private val jiraUrl: String,
+    @param:Value("\${jira.url}") private val jiraUrl: String,
 ) {
 
     private val log = LoggerFactory.getLogger(javaClass)

--- a/src/main/kotlin/br/com/jiratorio/jira/domain/JiraUser.kt
+++ b/src/main/kotlin/br/com/jiratorio/jira/domain/JiraUser.kt
@@ -4,10 +4,10 @@ import com.fasterxml.jackson.annotation.JsonProperty
 
 data class JiraUser(
 
-    @JsonProperty("displayName")
+    @field:JsonProperty("displayName")
     val name: String,
 
-    @JsonProperty("emailAddress")
+    @field:JsonProperty("emailAddress")
     val email: String
 
 )

--- a/src/main/kotlin/br/com/jiratorio/jira/provider/JiraBoardDataProvider.kt
+++ b/src/main/kotlin/br/com/jiratorio/jira/provider/JiraBoardDataProvider.kt
@@ -17,7 +17,7 @@ class JiraBoardDataProvider(
 
     override fun findDetails(externalId: Long): ExternalBoard =
         try {
-            projectClient.findById(externalId) ?: throw ResourceNotFound()
+            projectClient.findById(externalId)
         } catch (e: JiraNotFoundException) {
             throw ResourceNotFound()
         }

--- a/src/main/kotlin/br/com/jiratorio/jira/searcher/PagedIssueSearcher.kt
+++ b/src/main/kotlin/br/com/jiratorio/jira/searcher/PagedIssueSearcher.kt
@@ -32,7 +32,7 @@ class PagedIssueSearcher(
                 )
             )
             nodes.add(node)
-            nextPageToken = node.path("nextPageToken").asText(null)
+            nextPageToken = node.path("nextPageToken").stringValue()
         } while (nextPageToken != null)
 
         return nodes.flatMap { issueParser.parse(it, board, holidays, parseUnfinishedIssue) }

--- a/src/main/kotlin/br/com/jiratorio/service/WeeklyThroughputService.kt
+++ b/src/main/kotlin/br/com/jiratorio/service/WeeklyThroughputService.kt
@@ -21,7 +21,7 @@ class WeeklyThroughputService {
 
         val chart: Chart<String, Int> = Chart()
 
-        val temporalField: TemporalField = WeekFields.of(Locale("pt-BR")).dayOfWeek()
+        val temporalField: TemporalField = WeekFields.of(Locale.forLanguageTag("pt-BR")).dayOfWeek()
         var currentDate: LocalDate = startDate.with(temporalField, 1)
         val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern("dd/MM/yyyy")
 

--- a/src/main/kotlin/br/com/jiratorio/strategy/issueperiodnameformat/IssuePeriodNameFormatter.kt
+++ b/src/main/kotlin/br/com/jiratorio/strategy/issueperiodnameformat/IssuePeriodNameFormatter.kt
@@ -55,7 +55,7 @@ private open class PatternBasedFormatter(
 
     override fun format(startDate: LocalDate, endDate: LocalDate, locale: Locale): String =
         if (startDate.month == endDate.month && startDate.isFirstDayOfMonth && endDate.isLastDayOfMonth)
-            locale.formatter.format(startDate).replace(".", "").capitalize()
+            locale.formatter.format(startDate).replace(".", "").replaceFirstChar { if (it.isLowerCase()) it.titlecase(locale) else it.toString() }
         else
             InitialAndFinal.format(startDate, endDate, locale)
 

--- a/src/test/kotlin/br/com/jiratorio/strategy/issueperiodnameformat/IssuePeriodNameFormatTest.kt
+++ b/src/test/kotlin/br/com/jiratorio/strategy/issueperiodnameformat/IssuePeriodNameFormatTest.kt
@@ -42,7 +42,7 @@ class IssuePeriodNameFormatTest {
     )
     fun `should format with MONTH`(start: String, end: String, expected: String) {
         val result = IssuePeriodNameFormatter.from(IssuePeriodNameFormat.MONTH)
-            .format(start.toLocalDate(), end.toLocalDate(), Locale("pt", "BR'"))
+            .format(start.toLocalDate(), end.toLocalDate(), Locale.of("pt", "BR"))
 
         assertEquals(expected, result)
     }
@@ -65,7 +65,7 @@ class IssuePeriodNameFormatTest {
     )
     fun `should format with MONTH_AND_YEAR`(start: String, end: String, expected: String) {
         val result = IssuePeriodNameFormatter.from(IssuePeriodNameFormat.MONTH_AND_YEAR)
-            .format(start.toLocalDate(), end.toLocalDate(), Locale("pt", "BR'"))
+            .format(start.toLocalDate(), end.toLocalDate(), Locale.of("pt", "BR"))
 
         assertEquals(expected, result)
     }
@@ -88,7 +88,7 @@ class IssuePeriodNameFormatTest {
     )
     fun `should format with MONTH_AND_ABBREVIATED_YEAR`(start: String, end: String, expected: String) {
         val result = IssuePeriodNameFormatter.from(IssuePeriodNameFormat.MONTH_AND_ABBREVIATED_YEAR)
-            .format(start.toLocalDate(), end.toLocalDate(), Locale("pt", "BR'"))
+            .format(start.toLocalDate(), end.toLocalDate(), Locale.of("pt", "BR"))
 
         assertEquals(expected, result)
     }
@@ -111,7 +111,7 @@ class IssuePeriodNameFormatTest {
     )
     fun `should format with ABBREVIATED_MONTH`(start: String, end: String, expected: String) {
         val result = IssuePeriodNameFormatter.from(IssuePeriodNameFormat.ABBREVIATED_MONTH)
-            .format(start.toLocalDate(), end.toLocalDate(), Locale("pt", "BR'"))
+            .format(start.toLocalDate(), end.toLocalDate(), Locale.of("pt", "BR"))
 
         assertEquals(expected, result)
     }
@@ -134,7 +134,7 @@ class IssuePeriodNameFormatTest {
     )
     fun `should format with ABBREVIATED_MONTH_AND_YEAR`(start: String, end: String, expected: String) {
         val result = IssuePeriodNameFormatter.from(IssuePeriodNameFormat.ABBREVIATED_MONTH_AND_YEAR)
-            .format(start.toLocalDate(), end.toLocalDate(), Locale("pt", "BR'"))
+            .format(start.toLocalDate(), end.toLocalDate(), Locale.of("pt", "BR"))
 
         assertEquals(expected, result)
     }
@@ -157,7 +157,7 @@ class IssuePeriodNameFormatTest {
     )
     fun `should format with ABBREVIATED_MONTH_AND_ABBREVIATED_YEAR`(start: String, end: String, expected: String) {
         val result = IssuePeriodNameFormatter.from(IssuePeriodNameFormat.ABBREVIATED_MONTH_AND_ABBREVIATED_YEAR)
-            .format(start.toLocalDate(), end.toLocalDate(), Locale("pt", "BR'"))
+            .format(start.toLocalDate(), end.toLocalDate(), Locale.of("pt", "BR"))
 
         assertEquals(expected, result)
     }


### PR DESCRIPTION
- Replace -Xjvm-default=all with -jvm-default=enable
- Add @field:/@param: use-site targets on data class annotations
- Replace deprecated Locale constructors with Locale.of()/forLanguageTag()
- Replace deprecated Jackson asText()/textValue() with asString()/stringValue()
- Suppress @JacksonXmlRootElement deprecation (no replacement in Jackson 3 XML)
- Migrate JdbcTemplate query() to non-deprecated vararg overload
- Replace String.capitalize() with replaceFirstChar {}
- Remove dead null-safety operators on non-null types